### PR TITLE
Add missing multidict dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ keywords = [
 ]
 dependencies = [
     "asgiref",
+    "multidict",
     "protobuf",
     "requests",
     "structlog",


### PR DESCRIPTION
## Summary
- `twirp/exceptions.py` imports `multidict.CIMultiDictProxy` but `multidict` was not declared in `[project.dependencies]`
- This causes `ModuleNotFoundError: No module named 'multidict'` when the package is installed in a clean environment

## Test plan
- [x] Fresh venv install: `pip install -e .` → `from twirp.exceptions import TwirpServerException` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)