### PR TITLE
Bump version to 0.3.0-dev.3

### DIFF
--- a/twirp/__init__.py
+++ b/twirp/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0-dev.2"
+__version__ = "0.3.0-dev.3"


### PR DESCRIPTION
The published `0.3.0-dev.2` is missing `multidict` in its dependencies (it was added to `pyproject.toml` after the release). This bump allows publishing a new version that includes the fix.

After merging, create a release with tag `twirpy/0.3.0-dev.3` to trigger PyPI publish.